### PR TITLE
Área de Atuação - Scrollbar aparecendo no Firefox

### DIFF
--- a/components/OccupationSection/OccupationSection.module.css
+++ b/components/OccupationSection/OccupationSection.module.css
@@ -43,6 +43,7 @@
   overflow: scroll;
   scroll-behavior: smooth;
   -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
 }
 
 .itemContainer::-webkit-scrollbar {


### PR DESCRIPTION
#107 Aplicando correção da scrollbar aparecendo erroneamente no navegador Firefox na seção Área de Atuação